### PR TITLE
Add DreameVacuum

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,11 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 
+
+[*.js]
+indent_style = space
+indent_size = 2
+
 [*.json]
 indent_style = space
 indent_size = 2

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - release
+  categories:
+    - title: 🏕 New Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ⚙️ Other Changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies

--- a/lib/connectToDevice.js
+++ b/lib/connectToDevice.js
@@ -6,8 +6,9 @@ const Device = require('./device');
 const Placeholder = require('./placeholder');
 const models = require('./models');
 
-const Vacuum = require('./devices/vacuum');
-const ViomiVacuum = require('./devices/viomivacuum');
+const Vacuum = require('./devices/vacuums/vacuum');
+const ViomiVacuum = require('./devices/vacuums/viomivacuum');
+const DreameVacuum = require('./devices/vacuums/dreamevacuum');
 
 module.exports = function(options) {
 	let handle = network.ref();
@@ -26,8 +27,11 @@ module.exports = function(options) {
 			// Hack to accept any vacuum in the form of 'WORD.vacuum.*'
 			if (!d && device.model.match(/^\w+\.vacuum\./)) {
 				d = Vacuum;
-				if (device.model.startsWith('viomi')) {
+				if (device.model.startsWith('viomi.')) {
 					d = ViomiVacuum;
+				}
+				if (device.model.startsWith('dreame.')) {
+					d = DreameVacuum;
 				}
 			}
 

--- a/lib/devices/vacuums/dreamevacuum.js
+++ b/lib/devices/vacuums/dreamevacuum.js
@@ -1,0 +1,349 @@
+'use strict';
+
+const {ChargingState, AutonomousCharging} = require('abstract-things');
+const {
+  Vacuum,
+  AdjustableFanSpeed,
+  AutonomousCleaning,
+  SpotCleaning,
+} = require('abstract-things/climate');
+
+const MiioApi = require('../../device');
+const BatteryLevel = require('../capabilities/battery-level');
+const checkResult = require('../../checkResult');
+
+/**
+ * Implementation of the interface used by the Dreame Vacuum. This device
+ * doesn't use properties via get_prop but instead has a get_properties.
+ */
+module.exports = class extends (
+  Vacuum.with(
+    MiioApi,
+    BatteryLevel,
+    AutonomousCharging,
+    AutonomousCleaning,
+    SpotCleaning,
+    AdjustableFanSpeed,
+    ChargingState
+  )
+) {
+  static get type() {
+    return 'miio:vacuum';
+  }
+
+  constructor(options) {
+    super(options);
+
+    this.defineProperty('device_fault', {
+      name: 'error',
+      siid: 2,
+      piid: 2,
+      mapper: (e) => {
+        let message;
+        switch (e) {
+          // https://python-miio.readthedocs.io/en/latest/api/miio.integrations.dreame.vacuum.dreamevacuum_miot.html#miio.integrations.dreame.vacuum.dreamevacuum_miot.FaultStatus
+          case 0:
+            return null;
+          default:
+            message = 'Unknown error ' + e;
+        }
+        return {
+          code: e,
+          message,
+        };
+      },
+    });
+
+    this.defineProperty('device_status', {
+      name: 'state',
+      siid: 2,
+      piid: 1,
+      mapper: (s) => {
+        // https://python-miio.readthedocs.io/en/latest/api/miio.integrations.dreame.vacuum.dreamevacuum_miot.html#miio.integrations.dreame.vacuum.dreamevacuum_miot.DeviceStatus
+        switch (s) {
+          case 1:
+            return 'sweeping';
+          case 2:
+            return 'idle';
+          case 3:
+            return 'paused';
+          case 4:
+            return 'error';
+          case 5:
+            return 'returning';
+          case 6:
+            return 'charging';
+          case 7:
+            return 'mopping';
+          case 8:
+            return 'drying';
+          case 9:
+            return 'washing';
+          case 10:
+            return 'returning-washing';
+          case 11:
+            return 'building';
+          case 12:
+            return 'sweeping-and-mopping';
+          case 13:
+            return 'fully-charged';
+          case 14:
+            return 'updating';
+        }
+        return 'unknown-' + s;
+      }
+    });
+
+    // Define the batteryLevel property for monitoring battery
+    this.defineProperty('battery_level', {
+      name: 'batteryLevel',
+      siid: 3,
+      piid: 1,
+    });
+
+    this.defineProperty('charging_state', {
+      name: 'charging',
+      siid: 3,
+      piid: 2,
+      mapper: (s) => {
+        switch (s) {
+          case 1: // charging
+            return true;
+          case 2: // discharging
+            return false;
+          case 4: // charging2
+            return true;
+          case 5: // go-charging
+            return false;
+        }
+      }
+    });
+
+    this.defineProperty('cleaning_mode', {
+      name: 'fanSpeed',
+      siid: 18,
+      piid: 6
+    });
+    this.defineProperty('operating_mode', {
+      name: 'cleaningMode',
+      siid: 18,
+      piid: 1,
+      mapper: (v) => {
+        switch (v) {
+          case 1:
+            return 'paused';
+          case 2:
+            return 'cleaning';
+          case 3:
+            return 'returning';
+          case 6:
+            return 'charging';
+          case 13:
+            return 'manual-cleaning';
+          case 14:
+            return 'idle';
+          case 17:
+            return 'manual-paused';
+          case 19:
+            return 'zone-cleaning';
+        }
+        return 'unknown-' + v;
+      }
+    });
+
+    this.defineProperty('water_flow', {
+      name: 'waterBoxMode',
+      siid: 4,
+      piid: 5,
+    });
+
+    this._monitorInterval = 60000;
+  }
+
+  propertyUpdated(key, value, oldValue) {
+    if (key === 'state') {
+      // Update charging state
+      this.updateCharging(value === 'charging');
+
+      switch (value) {
+        case 'cleaning':
+        case 'spot-cleaning':
+        case 'zone-cleaning':
+        case 'room-cleaning':
+          // The vacuum is cleaning
+          this.updateCleaning(true);
+          break;
+        case 'paused':
+          // Cleaning has been paused, do nothing special
+          break;
+        case 'error':
+          // An error has occurred, rely on error mapping
+          this.updateError(this.property('error'));
+          break;
+        case 'charging-error':
+          // Charging error, trigger an error
+          this.updateError({
+            code: 'charging-error',
+            message: 'Error during charging',
+          });
+          break;
+        case 'charger-offline':
+          // Charger is offline, trigger an error
+          this.updateError({
+            code: 'charger-offline',
+            message: 'Charger is offline',
+          });
+          break;
+        default:
+          // The vacuum is not cleaning
+          this.updateCleaning(false);
+          break;
+      }
+    } else if (key === 'fanSpeed') {
+      this.updateFanSpeed(value);
+    }
+
+    super.propertyUpdated(key, value, oldValue);
+  }
+
+  getDeviceInfo() {
+    return this.call('miIO.info');
+  }
+
+  async getSerialNumber() {
+    return 'unknown';
+  }
+
+  getRoomMap() {
+    return [];
+  }
+
+  getTimer() {
+    return [];
+  }
+
+  /**
+   * Start a cleaning session.
+   */
+  activateCleaning() {
+    return this.call('action', {
+      did: 'start_clean',
+      siid: this.miioModel === 'dreame.vacuum.mc1808' ? 3 : 4,
+      aiid: 1,
+      in: []
+    }, {
+      refresh: ['state'],
+      refreshDelay: 1000,
+    }).then(checkResult);
+  }
+
+  /**
+   * Pause the current cleaning session.
+   */
+  pause() {
+    return this.deactivateCleaning();
+  }
+
+  /**
+   * Stop the current cleaning session.
+   */
+  deactivateCleaning() {
+    return this.call('action', {
+      did: 'stop_clean',
+      siid: this.miioModel === 'dreame.vacuum.mc1808' ? 3 : 4,
+      aiid: 2,
+      in: []
+    }, {
+      refresh: ['state'],
+      refreshDelay: 1000,
+    }).then(checkResult);
+  }
+
+  /**
+   * Stop the current cleaning session and return to charge.
+   */
+  activateCharging() {
+    return (
+      this.pause()
+        .catch(() => this.deactivateCleaning())
+        // Wait 1 second
+        .then(() => new Promise((resolve) => setTimeout(resolve, 1000)))
+        .then(() =>
+          this.call('action', {
+            did: 'home',
+            siid: this.miioModel === 'dreame.vacuum.mc1808' ? 2 : 3,
+            aiid: 1,
+            in: []
+          }, {
+            refresh: ['state'],
+            refreshDelay: 1000,
+          })
+        )
+        .then(checkResult)
+    );
+  }
+
+  /**
+   * Set the power of the fan. Usually 38, 60 or 77.
+   */
+  changeFanSpeed(speed) {
+    return this.call('set_properties', [{
+      did: 'cleaning_mode',
+      siid: 18,
+      piid: 6,
+      value: speed,
+    }], {
+      refresh: ['fanSpeed'],
+    }).then(checkResult);
+  }
+
+  setWaterBoxMode(mode) {
+    // From https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/water_box_custom_mode.md
+    return this.call('set_properties', [{
+      did: 'water_flow',
+      siid: 4,
+      piid: 5,
+      value: mode,
+    }], {
+      refresh: ['waterBoxMode'],
+    }).then(checkResult);
+  }
+
+  /**
+   * Activate the find function, will make the device give off a sound.
+   */
+  find() {
+    return this.call('action', {
+      did: 'locate',
+      siid: this.miioModel === 'dreame.vacuum.mc1808' ? 17 : 7,
+      aiid: 1,
+      in: []
+    }).then(() => null);
+  }
+
+  loadProperties(props) {
+    // We override loadProperties to use get_properties
+    props = props.map((key) => this._reversePropertyDefinitions[key] || key);
+
+    const properties = props.map((prop) => {
+      const definition = this._propertyDefinitions[prop];
+      if (definition) {
+        return {
+          did: prop,
+          siid: definition.siid,
+          piid: definition.piid,
+        };
+      }
+    }).filter(Boolean);
+
+    return this.call('get_properties', properties)
+      .then((result) => {
+      const mapped = {};
+      props.forEach((prop) => {
+        let value = result[prop];
+        this._pushProperty(mapped, prop, value);
+      });
+      return mapped;
+    });
+  }
+};

--- a/lib/devices/vacuums/mijiavacuum.js
+++ b/lib/devices/vacuums/mijiavacuum.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Vacuum = require('./vacuum');
-const checkResult = require('../checkResult');
+const checkResult = require('../../checkResult');
 
 module.exports = class extends Vacuum {
   async cleanRooms(listOfRooms) {

--- a/lib/devices/vacuums/vacuum.js
+++ b/lib/devices/vacuums/vacuum.js
@@ -8,9 +8,9 @@ const {
   SpotCleaning,
 } = require('abstract-things/climate');
 
-const MiioApi = require('../device');
-const BatteryLevel = require('./capabilities/battery-level');
-const checkResult = require('../checkResult');
+const MiioApi = require('../../device');
+const BatteryLevel = require('../capabilities/battery-level');
+const checkResult = require('../../checkResult');
 
 /**
  * Implementation of the interface used by the Mi Robot Vacuum. This device
@@ -197,7 +197,22 @@ module.exports = class extends (
     this.defineProperty('fan_power', {
       name: 'fanSpeed',
     });
-    this.defineProperty('in_cleaning');
+    this.defineProperty('in_cleaning', {
+      name: 'cleaningMode',
+      mapper: (v) => {
+        switch (v) {
+          case 0:
+            return 'idle';
+          case 1:
+            return 'cleaning';
+          case 2:
+            return 'zone-cleaning';
+          case 3:
+            return 'room-cleaning';
+        }
+        return 'unknown-' + v;
+      },
+    });
 
     this.defineProperty('in_returning');
 

--- a/lib/devices/vacuums/viomivacuum.js
+++ b/lib/devices/vacuums/viomivacuum.js
@@ -8,9 +8,9 @@ const {
   SpotCleaning,
 } = require('abstract-things/climate');
 
-const MiioApi = require('../device');
-const BatteryLevel = require('./capabilities/battery-level');
-const checkResult = require('../checkResult');
+const MiioApi = require('../../device');
+const BatteryLevel = require('../capabilities/battery-level');
+const checkResult = require('../../checkResult');
 
 module.exports = class extends (
   Vacuum.with(

--- a/lib/models.js
+++ b/lib/models.js
@@ -7,9 +7,9 @@ const AirMonitor = require('./devices/air-monitor');
 const AirPurifier = require('./devices/air-purifier');
 const Gateway = require('./devices/gateway');
 
-const Vacuum = require('./devices/vacuum');
-const MijiaVacuum = require('./devices/mijiavacuum');
-const ViomiVacuum = require('./devices/viomivacuum');
+const Vacuum = require('./devices/vacuums/vacuum');
+const MijiaVacuum = require('./devices/vacuums/mijiavacuum');
+const ViomiVacuum = require('./devices/vacuums/viomivacuum');
 
 const PowerPlug = require('./devices/power-plug');
 const PowerStrip = require('./devices/power-strip');
@@ -53,7 +53,6 @@ module.exports = {
 
 	'roborock.vacuum.m1s': MijiaVacuum,
 
-	'dreame.vacuum.mc1808': ViomiVacuum,
 	'viomi.vacuum.v7': ViomiVacuum,
 	'viomi.vacuum.v8': ViomiVacuum,
 


### PR DESCRIPTION
Using https://python-miio.readthedocs.io/en/latest/_modules/miio/integrations/dreame/vacuum/dreamevacuum_miot.html, I've tried to add support for the DreameVacuum.

Testing is still required.