### PR TITLE
Replace `appdirectory`

### DIFF
--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,16 +1,6 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
-const mkdirp = require('mkdirp');
-const AppDirectory = require('appdirectory');
-const dirs = new AppDirectory('miio');
-
-const CHECK_TIME = 1000;
-const MAX_STALE_TIME = 120000;
-
-const debug = require('debug')('miio:tokens');
+const storage = require('node-persist');
 
 /**
  * Shared storage for tokens of devices. Keeps a simple JSON file synced
@@ -18,111 +8,15 @@ const debug = require('debug')('miio:tokens');
  */
 class Tokens {
 	constructor() {
-		this._file = path.join(dirs.userData(), 'tokens.json');
-		this._data = {};
-		this._lastSync = 0;
+    this._storage = storage.initSync();
 	}
 
 	get(deviceId) {
-		const now = Date.now();
-		const diff = now - this._lastSync;
-
-		if(diff > CHECK_TIME) {
-			return this._loadAndGet(deviceId);
-		}
-
-		return Promise.resolve(this._get(deviceId));
-	}
-
-	_get(deviceId) {
-		return this._data[deviceId];
-	}
-
-	_loadAndGet(deviceId) {
-		return this._load()
-			.then(() => this._get(deviceId))
-			.catch(() => null);
-	}
-
-	_load() {
-		if(this._loading) return this._loading;
-
-		return this._loading = new Promise((resolve, reject) => {
-			debug('Loading token storage from', this._file);
-			fs.stat(this._file, (err, stat) => {
-				if(err) {
-					delete this._loading;
-					if(err.code === 'ENOENT') {
-						debug('Token storage does not exist');
-						this._lastSync = Date.now();
-						resolve(this._data);
-					} else {
-						reject(err);
-					}
-
-					return;
-				}
-
-				if(! stat.isFile()) {
-					// tokens.json does not exist
-					delete this._loading;
-					reject(new Error('tokens.json exists but is not a file'));
-				} else if(Date.now() - this._lastSync > MAX_STALE_TIME || stat.mtime.getTime() > this._lastSync) {
-					debug('Loading tokens');
-					fs.readFile(this._file, (err, result) =>  {
-						this._data = JSON.parse(result.toString());
-						this._lastSync = Date.now();
-						delete this._loading;
-						resolve(this._data);
-					});
-				} else {
-					delete this._loading;
-					this._lastSync = Date.now();
-					resolve(this._data);
-				}
-			});
-		});
+    return this._storage.getItem(deviceId);
 	}
 
 	update(deviceId, token) {
-		return this._load()
-			.then(() => {
-				this._data[deviceId] = token;
-
-				if(this._saving) {
-					this._dirty = true;
-					return this._saving;
-				}
-
-				return this._saving = new Promise((resolve, reject) => {
-					const save = () => {
-						debug('About to save tokens');
-						fs.writeFile(this._file, JSON.stringify(this._data, null, 2), (err) => {
-							if(err) {
-								reject(err);
-							} else {
-								if(this._dirty) {
-									debug('Redoing save due to multiple updates');
-									this._dirty = false;
-									save();
-								} else {
-									delete this._saving;
-									resolve();
-								}
-							}
-						});
-					};
-
-					mkdirp(dirs.userData(), (err) => {
-						if(err) {
-							reject(err);
-							return;
-						}
-
-						save();
-					});
-				});
-			});
+    return this._storage.setItem(deviceId, token);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "abstract-things": "^0.9.0",
-        "appdirectory": "^0.1.0",
         "chalk": "4.1.2",
         "debug": "4.4.1",
         "deep-equal": "2.2.3",
         "mkdirp": "^0.5.1",
+        "node-persist": "^4.0.4",
         "tinkerhub-discovery": "^0.3.1",
         "yargs": "15.4.1"
       },
@@ -5623,6 +5623,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-persist": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.4.tgz",
+      "integrity": "sha512-8sPAz/7tw1mCCc8xBG4f0wi+flHkSSgQeX998iQ75Pu27evA6UUWCjSE7xnrYTg2q33oU5leJ061EKPDv6BocQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/node-persist/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7375,7 +7402,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chalk": "4.1.2",
         "debug": "4.4.1",
         "deep-equal": "2.2.3",
-        "mkdirp": "^0.5.1",
         "node-persist": "^4.0.4",
         "tinkerhub-discovery": "^0.3.1",
         "yargs": "15.4.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "chalk": "4.1.2",
     "debug": "4.4.1",
     "deep-equal": "2.2.3",
-    "mkdirp": "^0.5.1",
     "node-persist": "^4.0.4",
     "tinkerhub-discovery": "^0.3.1",
     "yargs": "15.4.1"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "abstract-things": "^0.9.0",
-    "appdirectory": "^0.1.0",
     "chalk": "4.1.2",
     "debug": "4.4.1",
     "deep-equal": "2.2.3",
     "mkdirp": "^0.5.1",
+    "node-persist": "^4.0.4",
     "tinkerhub-discovery": "^0.3.1",
     "yargs": "15.4.1"
   },


### PR DESCRIPTION
AppDirectory has been deprecated for a long time, and there is a known bug that annoys many users: https://github.com/MrJohz/appdirectory/issues/2, https://github.com/afharo/matterbridge-xiaomi-roborock/issues/107

This PR replaces `appdirectory` with `node-persist`, making the Token's storage handling much easier.